### PR TITLE
feat: improve theme and timer label

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -102,7 +102,7 @@ class _HomePageState extends State<HomePage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('設定計時秒數'),
+          title: const Text('設定組間休息秒數'),
           content: TextField(
             controller: controller,
             keyboardType: TextInputType.number,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,19 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final seedColor = Colors.blue;
     return MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: seedColor,
+        brightness: Brightness.light,
+      ),
+      darkTheme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: seedColor,
+        brightness: Brightness.dark,
+      ),
+      themeMode: ThemeMode.system,
       home: const HomePage(),
     );
   }


### PR DESCRIPTION
## Summary
- improve app theme with Material 3 and system dark mode
- rename timer dialog title to clarify rest between sets

## Testing
- `dart format lib/main.dart lib/home_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1bbe2dc083218b6a317b13bbdcf9