### PR TITLE
Adopt Material 3 design across UI

### DIFF
--- a/lib/exercise_settings_page.dart
+++ b/lib/exercise_settings_page.dart
@@ -60,7 +60,7 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
           content: TextField(controller: controller),
           actions: [
             TextButton(onPressed: () => Navigator.pop(context), child: const Text('取消')),
-            ElevatedButton(
+            FilledButton(
               onPressed: () async {
                 if (id == null) {
                   await _db.insertCategory(controller.text);
@@ -92,7 +92,7 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
           content: TextField(controller: controller),
           actions: [
             TextButton(onPressed: () => Navigator.pop(context), child: const Text('取消')),
-            ElevatedButton(
+            FilledButton(
               onPressed: () async {
                 if (id == null) {
                   await _db.insertExercise(_selectedCategory!, controller.text);
@@ -155,7 +155,7 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
                         .toList(),
                   ),
                 ),
-                ElevatedButton(
+                FilledButton(
                   onPressed: () => _showCategoryDialog(),
                   child: const Text('新增類別'),
                 )
@@ -207,7 +207,7 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
                         .toList(),
                   ),
                 ),
-                ElevatedButton(
+                FilledButton(
                   onPressed: () => _showExerciseDialog(),
                   child: const Text('新增動作'),
                 )

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -25,6 +25,7 @@ class _HomePageState extends State<HomePage> {
   bool _isTiming = false;
   int _remainingSeconds = 0;
   Timer? _timer;
+  int _navIndex = 0;
 
   @override
   void initState() {
@@ -112,7 +113,7 @@ class _HomePageState extends State<HomePage> {
               onPressed: () => Navigator.pop(context),
               child: const Text('取消'),
             ),
-            ElevatedButton(
+            FilledButton(
               onPressed: () {
                 setState(() {
                   _timerSeconds = int.tryParse(controller.text) ?? _timerSeconds;
@@ -141,25 +142,25 @@ class _HomePageState extends State<HomePage> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              DropdownButton<int>(
-                value: _selectedCategory,
-                items: _categories
-                    .map((c) => DropdownMenuItem<int>(
+              DropdownMenu<int>(
+                initialSelection: _selectedCategory,
+                dropdownMenuEntries: _categories
+                    .map((c) => DropdownMenuEntry<int>(
                           value: c['id'] as int,
-                          child: Text(c['name'] as String),
+                          label: c['name'] as String,
                         ))
                     .toList(),
-                onChanged: _onCategoryChanged,
+                onSelected: _onCategoryChanged,
               ),
-              DropdownButton<int>(
-                value: _selectedExercise,
-                items: _exercises
-                    .map((e) => DropdownMenuItem<int>(
+              DropdownMenu<int>(
+                initialSelection: _selectedExercise,
+                dropdownMenuEntries: _exercises
+                    .map((e) => DropdownMenuEntry<int>(
                           value: e['id'] as int,
-                          child: Text(e['name'] as String),
+                          label: e['name'] as String,
                         ))
                     .toList(),
-                onChanged: (id) => setState(() => _selectedExercise = id),
+                onSelected: (id) => setState(() => _selectedExercise = id),
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -184,8 +185,8 @@ class _HomePageState extends State<HomePage> {
                 ],
               ),
               const SizedBox(height: 16),
-              ElevatedButton(
-                style: ElevatedButton.styleFrom(
+              FilledButton(
+                style: FilledButton.styleFrom(
                     shape: const CircleBorder(),
                     padding: const EdgeInsets.all(40)),
                 onPressed: _isTiming ? null : _startWorkout,
@@ -197,31 +198,33 @@ class _HomePageState extends State<HomePage> {
       ),
       bottomNavigationBar: AbsorbPointer(
         absorbing: _isTiming,
-        child: BottomAppBar(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceAround,
-            children: [
-              IconButton(onPressed: _showTimerDialog, icon: const Icon(Icons.timer)),
-              IconButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const ReportPage()),
-                  );
-                },
-                icon: const Icon(Icons.assessment),
-              ),
-              IconButton(
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(builder: (_) => const ExerciseSettingsPage()),
-                  ).then((_) => _loadData());
-                },
-                icon: const Icon(Icons.settings),
-              ),
-            ],
-          ),
+        child: NavigationBar(
+          selectedIndex: _navIndex,
+          onDestinationSelected: (index) {
+            setState(() => _navIndex = index);
+            switch (index) {
+              case 0:
+                _showTimerDialog();
+                break;
+              case 1:
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const ReportPage()),
+                );
+                break;
+              case 2:
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const ExerciseSettingsPage()),
+                ).then((_) => _loadData());
+                break;
+            }
+          },
+          destinations: const [
+            NavigationDestination(icon: Icon(Icons.timer), label: '計時'),
+            NavigationDestination(icon: Icon(Icons.assessment), label: '報表'),
+            NavigationDestination(icon: Icon(Icons.settings), label: '設定'),
+          ],
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'home_page.dart';
 
 void main() {
@@ -10,14 +11,56 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const seedColor = Colors.blue;
-    final lightScheme =
-        ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.light);
-    final darkScheme =
-        ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.dark);
+    const seedColor = Color(0xFF6750A4);
+    const secondaryColor = Color(0xFF00BFA6);
+
+    ThemeData buildTheme(Brightness brightness) {
+      final base = ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: seedColor,
+          secondary: secondaryColor,
+          brightness: brightness,
+        ),
+        fontFamily: 'Inter',
+        fontFamilyFallback: const ['Noto Sans TC'],
+      );
+      return base.copyWith(
+        textTheme: GoogleFonts.interTextTheme(base.textTheme)
+            .apply(fontFamilyFallback: const ['Noto Sans TC']),
+        cardTheme: const CardTheme(
+          margin: EdgeInsets.all(16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.all(Radius.circular(16)),
+          ),
+          elevation: 1,
+        ),
+        elevatedButtonTheme: ElevatedButtonThemeData(
+          style: ButtonStyle(
+            shape: const WidgetStatePropertyAll(
+              RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(Radius.circular(12)),
+              ),
+            ),
+            elevation: const WidgetStatePropertyAll(1),
+          ),
+        ),
+        inputDecorationTheme: InputDecorationTheme(
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: const BorderSide(width: 2),
+          ),
+        ),
+      );
+    }
+
     return MaterialApp(
-      theme: ThemeData(colorScheme: lightScheme, useMaterial3: true),
-      darkTheme: ThemeData(colorScheme: darkScheme, useMaterial3: true),
+      theme: buildTheme(Brightness.light),
+      darkTheme: buildTheme(Brightness.dark),
       themeMode: ThemeMode.system,
       home: const HomePage(),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,18 +10,14 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final seedColor = Colors.blue;
+    const seedColor = Colors.blue;
+    final lightScheme =
+        ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.light);
+    final darkScheme =
+        ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.dark);
     return MaterialApp(
-      theme: ThemeData(
-        useMaterial3: true,
-        colorSchemeSeed: seedColor,
-        brightness: Brightness.light,
-      ),
-      darkTheme: ThemeData(
-        useMaterial3: true,
-        colorSchemeSeed: seedColor,
-        brightness: Brightness.dark,
-      ),
+      theme: ThemeData(colorScheme: lightScheme, useMaterial3: true),
+      darkTheme: ThemeData(colorScheme: darkScheme, useMaterial3: true),
       themeMode: ThemeMode.system,
       home: const HomePage(),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,6 @@ class MyApp extends StatelessWidget {
           secondary: secondaryColor,
           brightness: brightness,
         ),
-        fontFamily: 'Inter',
       );
       return base.copyWith(
         textTheme: GoogleFonts.interTextTheme(base.textTheme),
@@ -35,12 +34,12 @@ class MyApp extends StatelessWidget {
         ),
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ButtonStyle(
-            shape: const MaterialStatePropertyAll(
+            shape: const WidgetStatePropertyAll(
               RoundedRectangleBorder(
                 borderRadius: BorderRadius.all(Radius.circular(12)),
               ),
             ),
-            elevation: const MaterialStatePropertyAll(1),
+            elevation: const WidgetStatePropertyAll(1),
           ),
         ),
         inputDecorationTheme: InputDecorationTheme(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,11 +23,9 @@ class MyApp extends StatelessWidget {
           brightness: brightness,
         ),
         fontFamily: 'Inter',
-        fontFamilyFallback: const ['Noto Sans TC'],
       );
       return base.copyWith(
-        textTheme: GoogleFonts.interTextTheme(base.textTheme)
-            .apply(fontFamilyFallback: const ['Noto Sans TC']),
+        textTheme: GoogleFonts.interTextTheme(base.textTheme),
         cardTheme: const CardTheme(
           margin: EdgeInsets.all(16),
           shape: RoundedRectangleBorder(
@@ -37,12 +35,12 @@ class MyApp extends StatelessWidget {
         ),
         elevatedButtonTheme: ElevatedButtonThemeData(
           style: ButtonStyle(
-            shape: const WidgetStatePropertyAll(
+            shape: const MaterialStatePropertyAll(
               RoundedRectangleBorder(
                 borderRadius: BorderRadius.all(Radius.circular(12)),
               ),
             ),
-            elevation: const WidgetStatePropertyAll(1),
+            elevation: const MaterialStatePropertyAll(1),
           ),
         ),
         inputDecorationTheme: InputDecorationTheme(

--- a/lib/report_page.dart
+++ b/lib/report_page.dart
@@ -94,27 +94,16 @@ class _ReportPageState extends State<ReportPage> {
       appBar: AppBar(title: const Text('報表')),
       body: Column(
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              ChoiceChip(
-                label: const Text('日'),
-                selected: _period == _Period.day,
-                onSelected: (_) => _changePeriod(_Period.day),
-              ),
-              const SizedBox(width: 8),
-              ChoiceChip(
-                label: const Text('周'),
-                selected: _period == _Period.week,
-                onSelected: (_) => _changePeriod(_Period.week),
-              ),
-              const SizedBox(width: 8),
-              ChoiceChip(
-                label: const Text('月'),
-                selected: _period == _Period.month,
-                onSelected: (_) => _changePeriod(_Period.month),
-              ),
-            ],
+          Center(
+            child: SegmentedButton<_Period>(
+              segments: const [
+                ButtonSegment(value: _Period.day, label: Text('日')),
+                ButtonSegment(value: _Period.week, label: Text('周')),
+                ButtonSegment(value: _Period.month, label: Text('月')),
+              ],
+              selected: {_period},
+              onSelectionChanged: (s) => _changePeriod(s.first),
+            ),
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   sqflite: ^2.3.3
   path: ^1.9.0
+  google_fonts: ^6.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- replace color scheme and theme setup to fully enable Material 3
- refactor pages to use Material 3 widgets (DropdownMenu, FilledButton, NavigationBar, SegmentedButton)

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac46b689088321b4cbaf4fcd40a8e9