### PR TITLE
Refactor exercise settings to accordion with swipe actions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   sqflite: ^2.3.3
   path: ^1.9.0
+  flutter_slidable: ^3.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Replace two-panel exercise settings view with accordion-style list of categories
- Add per-category exercise lists and contextual add buttons
- Integrate flutter_slidable for swipe-to-edit/delete actions and add dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aeadfd22a08321a432faaf915cd84c