### PR TITLE
Persist workout settings

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -40,17 +40,28 @@ class _HomePageState extends State<HomePage> {
   }
 
   Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
     final cats = await _db.getCategories();
+    final savedCat = prefs.getInt('selectedCategory');
     int? firstCat = cats.isNotEmpty ? cats.first['id'] as int : null;
+    int? catId =
+        savedCat != null && cats.any((c) => c['id'] == savedCat) ? savedCat : firstCat;
+
     List<Map<String, dynamic>> exs = [];
-    if (firstCat != null) {
-      exs = await _db.getExercises(firstCat);
+    if (catId != null) {
+      exs = await _db.getExercises(catId);
     }
+    final savedEx = prefs.getInt('selectedExercise');
+    int? exId =
+        savedEx != null && exs.any((e) => e['id'] == savedEx)
+            ? savedEx
+            : (exs.isNotEmpty ? exs.first['id'] as int : null);
+
     setState(() {
       _categories = cats;
-      _selectedCategory = firstCat;
+      _selectedCategory = catId;
       _exercises = exs;
-      _selectedExercise = exs.isNotEmpty ? exs.first['id'] as int : null;
+      _selectedExercise = exId;
       _loading = false;
     });
   }
@@ -69,6 +80,12 @@ class _HomePageState extends State<HomePage> {
     await prefs.setInt('timerSeconds', _timerSeconds);
     await prefs.setInt('reps', reps);
     await prefs.setDouble('weight', weight);
+    if (_selectedCategory != null) {
+      await prefs.setInt('selectedCategory', _selectedCategory!);
+    }
+    if (_selectedExercise != null) {
+      await prefs.setInt('selectedExercise', _selectedExercise!);
+    }
   }
 
   @override
@@ -87,6 +104,7 @@ class _HomePageState extends State<HomePage> {
       _exercises = exs;
       _selectedExercise = exs.isNotEmpty ? exs.first['id'] as int : null;
     });
+    unawaited(_saveSettings());
   }
 
   Future<void> _startWorkout() async {
@@ -200,7 +218,10 @@ class _HomePageState extends State<HomePage> {
                         ),
                       )
                       .toList(),
-                  onChanged: (id) => setState(() => _selectedExercise = id),
+                  onChanged: (id) {
+                    setState(() => _selectedExercise = id);
+                    unawaited(_saveSettings());
+                  },
                 ),
                 SizedBox(height: ScreenUtil.h(16)),
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   sqflite: ^2.3.3
   path: ^1.9.0
   flutter_slidable: ^3.0.1
+  shared_preferences: ^2.3.2
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:irondiary/main.dart';
 
 void main() {
   sqfliteFfiInit();
   databaseFactory = databaseFactoryFfi;
+  SharedPreferences.setMockInitialValues({});
 
   testWidgets('home page has two dropdowns', (tester) async {
     await tester.pumpWidget(const MyApp());

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,11 +7,22 @@ import 'package:irondiary/main.dart';
 void main() {
   sqfliteFfiInit();
   databaseFactory = databaseFactoryFfi;
-  SharedPreferences.setMockInitialValues({});
 
   testWidgets('home page has two dropdowns', (tester) async {
+    SharedPreferences.setMockInitialValues({});
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
     expect(find.byType(DropdownButton), findsNWidgets(2));
+  });
+
+  testWidgets('loads saved selections for dropdowns', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'selectedCategory': 2,
+      'selectedExercise': 7,
+    });
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+    expect(find.text('肩'), findsOneWidget);
+    expect(find.text('槓鈴肩推'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- remember timer, reps, and weight settings between app launches using SharedPreferences
- update widget tests to mock SharedPreferences
- add shared_preferences package dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b11322938c83218e0f5b91655c1588