### PR TITLE
Make UI responsive across pages

### DIFF
--- a/lib/exercise_settings_page.dart
+++ b/lib/exercise_settings_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'database_helper.dart';
+import 'screen_util.dart';
 
 class ExerciseSettingsPage extends StatefulWidget {
   const ExerciseSettingsPage({super.key});
@@ -166,7 +167,8 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
         ],
       ),
       child: Card(
-        margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        margin: EdgeInsets.symmetric(
+            horizontal: ScreenUtil.w(8), vertical: ScreenUtil.h(4)),
         child: ListTile(
           leading: ReorderableDragStartListener(
             index: index,
@@ -233,7 +235,8 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
         ],
       ),
       child: Card(
-        margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        margin: EdgeInsets.symmetric(
+            horizontal: ScreenUtil.w(8), vertical: ScreenUtil.h(4)),
         child: ExpansionTile(
           leading: ReorderableDragStartListener(
             index: index,
@@ -278,11 +281,11 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
           ? Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                const Icon(Icons.info_outline,
-                    size: 80, color: Colors.grey),
-                const SizedBox(height: 16),
+                Icon(Icons.info_outline,
+                    size: ScreenUtil.w(80), color: Colors.grey),
+                SizedBox(height: ScreenUtil.h(16)),
                 const Text('您尚未建立任何動作類別，點擊下方按鈕開始吧！'),
-                const SizedBox(height: 16),
+                SizedBox(height: ScreenUtil.h(16)),
                 ElevatedButton(
                   onPressed: () => _showCategoryDialog(),
                   child: const Text('新增類別'),
@@ -301,14 +304,14 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
                     ],
                   ),
                 ),
-                const SizedBox(height: 16),
+                SizedBox(height: ScreenUtil.h(16)),
                 Center(
                   child: ElevatedButton(
                     onPressed: () => _showCategoryDialog(),
                     child: const Text('新增類別'),
                   ),
                 ),
-                const SizedBox(height: 16),
+                SizedBox(height: ScreenUtil.h(16)),
               ],
             ),
     );

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -452,38 +452,43 @@ class _NumberRowState extends State<NumberRow> {
               SizedBox(width: ScreenUtil.w(8)),
               widget.labelTrailing!,
             ],
-            const Spacer(),
-            OutlinedButton(
-              onPressed: widget.onMinus,
-              style: OutlinedButton.styleFrom(
-                visualDensity: VisualDensity.compact,
-                minimumSize:
-                    Size(ScreenUtil.w(36), ScreenUtil.w(36)),
+            Flexible(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  OutlinedButton(
+                    onPressed: widget.onMinus,
+                    style: OutlinedButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      minimumSize:
+                          Size(ScreenUtil.w(36), ScreenUtil.w(36)),
+                    ),
+                    child: Icon(Icons.remove, size: ScreenUtil.w(20)),
+                  ),
+                  SizedBox(width: ScreenUtil.w(8)),
+                  Flexible(
+                    child: TextField(
+                      controller: _c,
+                      textAlign: TextAlign.center,
+                      keyboardType: widget.keyboardType,
+                      inputFormatters: widget.inputFormatters,
+                      onSubmitted: widget.onSubmitted,
+                      style: TextStyle(fontSize: ScreenUtil.w(16)),
+                      decoration: const InputDecoration(isDense: true),
+                    ),
+                  ),
+                  SizedBox(width: ScreenUtil.w(8)),
+                  OutlinedButton(
+                    onPressed: widget.onPlus,
+                    style: OutlinedButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      minimumSize:
+                          Size(ScreenUtil.w(36), ScreenUtil.w(36)),
+                    ),
+                    child: Icon(Icons.add, size: ScreenUtil.w(20)),
+                  ),
+                ],
               ),
-              child: Icon(Icons.remove, size: ScreenUtil.w(20)),
-            ),
-            SizedBox(width: ScreenUtil.w(8)),
-            SizedBox(
-              width: ScreenUtil.w(56),
-              child: TextField(
-                controller: _c,
-                textAlign: TextAlign.center,
-                keyboardType: widget.keyboardType,
-                inputFormatters: widget.inputFormatters,
-                onSubmitted: widget.onSubmitted,
-                style: TextStyle(fontSize: ScreenUtil.w(16)),
-                decoration: const InputDecoration(isDense: true),
-              ),
-            ),
-            SizedBox(width: ScreenUtil.w(8)),
-            OutlinedButton(
-              onPressed: widget.onPlus,
-              style: OutlinedButton.styleFrom(
-                visualDensity: VisualDensity.compact,
-                minimumSize:
-                    Size(ScreenUtil.w(36), ScreenUtil.w(36)),
-              ),
-              child: Icon(Icons.add, size: ScreenUtil.w(20)),
             ),
           ],
         ),

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -217,7 +217,12 @@ class _HomePageState extends State<HomePage> {
                           value: c['id'] as int,
                           child: Text(
                             c['name'] as String,
-                            style: TextStyle(fontSize: ScreenUtil.w(16)),
+                            style: TextStyle(
+                              fontSize: ScreenUtil.w(16),
+                              color: Theme.of(
+                                context,
+                              ).textTheme.bodyLarge?.color,
+                            ),
                           ),
                         ),
                       )
@@ -237,7 +242,12 @@ class _HomePageState extends State<HomePage> {
                           value: e['id'] as int,
                           child: Text(
                             e['name'] as String,
-                            style: TextStyle(fontSize: ScreenUtil.w(16)),
+                            style: TextStyle(
+                              fontSize: ScreenUtil.w(16),
+                              color: Theme.of(
+                                context,
+                              ).textTheme.bodyLarge?.color,
+                            ),
                           ),
                         ),
                       )
@@ -252,7 +262,7 @@ class _HomePageState extends State<HomePage> {
                 // 數值列：左右留白已由外層 padding 提供
                 NumberRow(
                   label: '次數',
-                  labelTrailing: SizedBox(width: ScreenUtil.w(36)),
+                  labelTrailing: SizedBox(width: ScreenUtil.w(64)),
                   valueText: reps.toString(),
                   onMinus: () {
                     setState(() => reps = (reps - 1).clamp(0, 999));
@@ -275,6 +285,7 @@ class _HomePageState extends State<HomePage> {
                     onPressed: _toggleWeightUnit,
                     style: const ButtonStyle(
                       visualDensity: VisualDensity.compact,
+                      //minimumSize: Size(ScreenUtil.w(36), ScreenUtil.w(36)),
                     ),
                     child: Text(_weightUnit),
                   ),
@@ -370,14 +381,11 @@ Widget prettyDropdown<T>({
     style: TextStyle(fontSize: ScreenUtil.w(16)),
     items: items,
     onChanged: onChanged,
-    icon: Icon(
-      Icons.keyboard_arrow_down_rounded,
-      size: ScreenUtil.w(24),
-    ),
+    icon: Icon(Icons.keyboard_arrow_down_rounded, size: ScreenUtil.w(24)),
     decoration: InputDecoration(
       labelText: label,
       filled: true,
-      fillColor: cs.surfaceContainerHighest,
+      fillColor: cs.surfaceContainerHigh,
       contentPadding: EdgeInsets.symmetric(
         horizontal: ScreenUtil.w(16),
         vertical: ScreenUtil.h(14),
@@ -443,29 +451,43 @@ class _NumberRowState extends State<NumberRow> {
         padding: EdgeInsets.all(ScreenUtil.w(8)),
         child: Row(
           children: [
-            Text(
-              widget.label,
-              style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                    fontSize: ScreenUtil.w(16),
-                  ),
-            ),
-            if (widget.labelTrailing != null) ...[
-              SizedBox(width: ScreenUtil.w(8)),
-              widget.labelTrailing!,
-            ],
+            SizedBox(width: ScreenUtil.w(8)),
             Flexible(
+              flex: 1,
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
                 children: [
-                  OutlinedButton(
-                    onPressed: widget.onMinus,
-                    style: OutlinedButton.styleFrom(
-                      visualDensity: VisualDensity.compact,
-                      minimumSize:
-                          Size(ScreenUtil.w(36), ScreenUtil.w(36)),
+                  Text(
+                    widget.label,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontSize: ScreenUtil.w(16),
                     ),
-                    child: Icon(Icons.remove, size: ScreenUtil.w(20)),
                   ),
+                  if (widget.labelTrailing != null) ...[
+                    SizedBox(width: ScreenUtil.w(8)),
+                    widget.labelTrailing!,
+                    SizedBox(width: ScreenUtil.w(8)),
+                  ],
+                ],
+              ),
+            ),
+            Flexible(
+              flex: 1,
+              child: Row(
+                //mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Flexible(
+                    child: IconButton(
+                      onPressed: widget.onMinus,
+                      style: IconButton.styleFrom(
+                        shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(100)),
+                          side: BorderSide(width: 1),
+                        ),
+                      ),
+                      icon: Icon(Icons.remove, size: ScreenUtil.w(16)),
+                    ),
+                  ),
+
                   SizedBox(width: ScreenUtil.w(8)),
                   Flexible(
                     child: TextField(
@@ -478,15 +500,19 @@ class _NumberRowState extends State<NumberRow> {
                       decoration: const InputDecoration(isDense: true),
                     ),
                   ),
+
                   SizedBox(width: ScreenUtil.w(8)),
-                  OutlinedButton(
-                    onPressed: widget.onPlus,
-                    style: OutlinedButton.styleFrom(
-                      visualDensity: VisualDensity.compact,
-                      minimumSize:
-                          Size(ScreenUtil.w(36), ScreenUtil.w(36)),
+                  Flexible(
+                    child: IconButton(
+                      onPressed: widget.onPlus,
+                      style: IconButton.styleFrom(
+                        shape: const RoundedRectangleBorder(
+                          borderRadius: BorderRadius.all(Radius.circular(100)),
+                          side: BorderSide(width: 1),
+                        ),
+                      ),
+                      icon: Icon(Icons.add, size: ScreenUtil.w(16)),
                     ),
-                    child: Icon(Icons.add, size: ScreenUtil.w(20)),
                   ),
                 ],
               ),

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -193,7 +193,6 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
-    ScreenUtil.init(context);
     if (_loading) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -252,6 +252,7 @@ class _HomePageState extends State<HomePage> {
                 // 數值列：左右留白已由外層 padding 提供
                 NumberRow(
                   label: '次數',
+                  labelTrailing: SizedBox(width: ScreenUtil.w(36)),
                   valueText: reps.toString(),
                   onMinus: () {
                     setState(() => reps = (reps - 1).clamp(0, 999));

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -215,7 +215,10 @@ class _HomePageState extends State<HomePage> {
                       .map(
                         (c) => DropdownMenuItem(
                           value: c['id'] as int,
-                          child: Text(c['name'] as String),
+                          child: Text(
+                            c['name'] as String,
+                            style: TextStyle(fontSize: ScreenUtil.w(16)),
+                          ),
                         ),
                       )
                       .toList(),
@@ -232,7 +235,10 @@ class _HomePageState extends State<HomePage> {
                       .map(
                         (e) => DropdownMenuItem(
                           value: e['id'] as int,
-                          child: Text(e['name'] as String),
+                          child: Text(
+                            e['name'] as String,
+                            style: TextStyle(fontSize: ScreenUtil.w(16)),
+                          ),
                         ),
                       )
                       .toList(),
@@ -360,9 +366,13 @@ Widget prettyDropdown<T>({
   return DropdownButtonFormField<T>(
     value: value,
     isExpanded: true,
+    style: TextStyle(fontSize: ScreenUtil.w(16)),
     items: items,
     onChanged: onChanged,
-    icon: const Icon(Icons.keyboard_arrow_down_rounded),
+    icon: Icon(
+      Icons.keyboard_arrow_down_rounded,
+      size: ScreenUtil.w(24),
+    ),
     decoration: InputDecoration(
       labelText: label,
       filled: true,
@@ -432,7 +442,12 @@ class _NumberRowState extends State<NumberRow> {
         padding: EdgeInsets.all(ScreenUtil.w(8)),
         child: Row(
           children: [
-            Text(widget.label, style: Theme.of(context).textTheme.titleMedium),
+            Text(
+              widget.label,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontSize: ScreenUtil.w(16),
+                  ),
+            ),
             if (widget.labelTrailing != null) ...[
               SizedBox(width: ScreenUtil.w(8)),
               widget.labelTrailing!,
@@ -440,8 +455,12 @@ class _NumberRowState extends State<NumberRow> {
             const Spacer(),
             OutlinedButton(
               onPressed: widget.onMinus,
-              style: const ButtonStyle(visualDensity: VisualDensity.compact),
-              child: const Icon(Icons.remove),
+              style: OutlinedButton.styleFrom(
+                visualDensity: VisualDensity.compact,
+                minimumSize:
+                    Size(ScreenUtil.w(36), ScreenUtil.w(36)),
+              ),
+              child: Icon(Icons.remove, size: ScreenUtil.w(20)),
             ),
             SizedBox(width: ScreenUtil.w(8)),
             SizedBox(
@@ -452,14 +471,19 @@ class _NumberRowState extends State<NumberRow> {
                 keyboardType: widget.keyboardType,
                 inputFormatters: widget.inputFormatters,
                 onSubmitted: widget.onSubmitted,
+                style: TextStyle(fontSize: ScreenUtil.w(16)),
                 decoration: const InputDecoration(isDense: true),
               ),
             ),
             SizedBox(width: ScreenUtil.w(8)),
             OutlinedButton(
               onPressed: widget.onPlus,
-              style: const ButtonStyle(visualDensity: VisualDensity.compact),
-              child: const Icon(Icons.add),
+              style: OutlinedButton.styleFrom(
+                visualDensity: VisualDensity.compact,
+                minimumSize:
+                    Size(ScreenUtil.w(36), ScreenUtil.w(36)),
+              ),
+              child: Icon(Icons.add, size: ScreenUtil.w(20)),
             ),
           ],
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'home_page.dart';
+import 'screen_util.dart';
 
 void main() {
   runApp(const MyApp());
@@ -12,6 +13,10 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final seedColor = Colors.blue;
     return MaterialApp(
+      builder: (context, child) {
+        ScreenUtil.init(context);
+        return child!;
+      },
       theme: ThemeData(
         useMaterial3: true,
         colorSchemeSeed: seedColor,

--- a/lib/report_page.dart
+++ b/lib/report_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'database_helper.dart';
+import 'screen_util.dart';
 
 enum _Period { day, week, month }
 
@@ -102,13 +103,13 @@ class _ReportPageState extends State<ReportPage> {
                 selected: _period == _Period.day,
                 onSelected: (_) => _changePeriod(_Period.day),
               ),
-              const SizedBox(width: 8),
+              SizedBox(width: ScreenUtil.w(8)),
               ChoiceChip(
                 label: const Text('周'),
                 selected: _period == _Period.week,
                 onSelected: (_) => _changePeriod(_Period.week),
               ),
-              const SizedBox(width: 8),
+              SizedBox(width: ScreenUtil.w(8)),
               ChoiceChip(
                 label: const Text('月'),
                 selected: _period == _Period.month,
@@ -116,13 +117,16 @@ class _ReportPageState extends State<ReportPage> {
               ),
             ],
           ),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              IconButton(onPressed: () => _shift(-1), icon: const Icon(Icons.arrow_left)),
-              Text(_title()),
-              IconButton(onPressed: () => _shift(1), icon: const Icon(Icons.arrow_right)),
-            ],
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: ScreenUtil.w(16)),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                IconButton(onPressed: () => _shift(-1), icon: const Icon(Icons.arrow_left)),
+                Text(_title()),
+                IconButton(onPressed: () => _shift(1), icon: const Icon(Icons.arrow_right)),
+              ],
+            ),
           ),
           Expanded(
             child: ListView(


### PR DESCRIPTION
## Summary
- initialize ScreenUtil globally for consistent scaling
- adapt report and exercise settings pages to responsive dimensions
- remove redundant per-page ScreenUtil initialization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b15db4864083219c80ef5904ae5d09