### PR TITLE
Fix reordering UnsupportedError in exercise settings

### DIFF
--- a/lib/exercise_settings_page.dart
+++ b/lib/exercise_settings_page.dart
@@ -24,7 +24,11 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
     final cats = await _db.getCategories();
     final List<Map<String, dynamic>> withExs = [];
     for (final c in cats) {
-      final exs = await _db.getExercises(c['id'] as int);
+      // Convert the query result to a modifiable list. Sqflite's QueryResultSet
+      // is read-only and attempting to modify it (e.g. during reordering)
+      // will throw an UnsupportedError.
+      final exs = List<Map<String, dynamic>>.from(
+          await _db.getExercises(c['id'] as int));
       withExs.add({...c, 'exercises': exs});
     }
     setState(() {


### PR DESCRIPTION
## Summary
- Convert query results into modifiable lists when loading exercises to allow reordering without runtime errors.

## Testing
- `flutter test` *(fails: bash: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b51574a6808321b23d18dadab2efee