### PR TITLE
Add distribution report tab with category filtering and date ranges

### DIFF
--- a/lib/report_page.dart
+++ b/lib/report_page.dart
@@ -542,25 +542,28 @@ class _ReportPageState extends State<ReportPage> {
             TextButton(onPressed: _cycleDistRange, child: Text(_distRangeLabel())),
           ],
         ),
-        SizedBox(
-          height: 200,
-          child: PieChart(
-            PieChartData(
-              sectionsSpace: 2,
-              sections: entries.asMap().entries.map((entry) {
-                final index = entry.key;
-                final e = entry.value;
-                final color =
-                    Colors.primaries[index % Colors.primaries.length];
-                return PieChartSectionData(
-                  value: e.value,
-                  color: color,
-                  title: e.key,
-                  radius: 60,
-                  titlePositionPercentageOffset: 1.4,
-                  titleStyle: const TextStyle(fontSize: 12),
-                );
-              }).toList(),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          child: SizedBox(
+            height: 200,
+            child: PieChart(
+              PieChartData(
+                sectionsSpace: 2,
+                sections: entries.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final e = entry.value;
+                  final color =
+                      Colors.primaries[index % Colors.primaries.length];
+                  return PieChartSectionData(
+                    value: e.value,
+                    color: color,
+                    title: e.key,
+                    radius: 60,
+                    titlePositionPercentageOffset: 1.4,
+                    titleStyle: const TextStyle(fontSize: 12),
+                  );
+                }).toList(),
+              ),
             ),
           ),
         ),

--- a/lib/report_page.dart
+++ b/lib/report_page.dart
@@ -520,28 +520,23 @@ class _ReportPageState extends State<ReportPage> {
     final total = entries.fold<double>(0, (p, e) => p + e.value);
     return Column(
       children: [
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            DropdownButton<int?> (
-              hint: const Text('部位'),
-              value: _selectedCategoryId,
-              items: [
-                const DropdownMenuItem<int?> (
-                    value: null, child: Text('全部')),
-                ..._categories.map(
-                  (c) => DropdownMenuItem<int?> (
-                    value: c['id'] as int,
-                    child: Text(c['name'] as String),
-                  ),
-                ),
-              ],
-              onChanged: (v) => _onCategoryChanged(v),
+        DropdownButton<int?>(
+          hint: const Text('部位'),
+          value: _selectedCategoryId,
+          items: [
+            const DropdownMenuItem<int?> (
+                value: null, child: Text('全部')),
+            ..._categories.map(
+              (c) => DropdownMenuItem<int?> (
+                value: c['id'] as int,
+                child: Text(c['name'] as String),
+              ),
             ),
-            const SizedBox(width: 16),
-            TextButton(onPressed: _cycleDistRange, child: Text(_distRangeLabel())),
           ],
+          onChanged: (v) => _onCategoryChanged(v),
         ),
+        const SizedBox(height: 8),
+        TextButton(onPressed: _cycleDistRange, child: Text(_distRangeLabel())),
         Padding(
           padding: const EdgeInsets.symmetric(vertical: 16),
           child: SizedBox(
@@ -559,7 +554,6 @@ class _ReportPageState extends State<ReportPage> {
                     color: color,
                     title: e.key,
                     radius: 60,
-                    titlePositionPercentageOffset: 1.4,
                     titleStyle: const TextStyle(fontSize: 12),
                   );
                 }).toList(),

--- a/lib/report_page.dart
+++ b/lib/report_page.dart
@@ -546,17 +546,18 @@ class _ReportPageState extends State<ReportPage> {
           height: 200,
           child: PieChart(
             PieChartData(
+              sectionsSpace: 2,
               sections: entries.asMap().entries.map((entry) {
                 final index = entry.key;
                 final e = entry.value;
                 final color =
                     Colors.primaries[index % Colors.primaries.length];
-                final percent = total == 0 ? 0 : e.value / total * 100;
                 return PieChartSectionData(
                   value: e.value,
                   color: color,
-                  title: '${percent.toStringAsFixed(1)}%',
+                  title: e.key,
                   radius: 60,
+                  titlePositionPercentageOffset: 1.4,
                   titleStyle: const TextStyle(fontSize: 12),
                 );
               }).toList(),
@@ -564,23 +565,22 @@ class _ReportPageState extends State<ReportPage> {
           ),
         ),
         Expanded(
-          child: ListView.builder(
-            itemCount: entries.length,
-            itemBuilder: (context, index) {
-              final e = entries[index];
-              final percent = total == 0 ? 0 : e.value / total * 100;
-              return Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(child: Text(e.key)),
-                    Text('${percent.toStringAsFixed(1)}%'),
-                    Text('${e.value.toStringAsFixed(1)}kg'),
-                  ],
-                ),
-              );
-            },
+          child: SingleChildScrollView(
+            child: DataTable(
+              columns: const [
+                DataColumn(label: Text('名稱')),
+                DataColumn(label: Text('百分比')),
+                DataColumn(label: Text('總訓練量')),
+              ],
+              rows: entries.map((e) {
+                final percent = total == 0 ? 0 : e.value / total * 100;
+                return DataRow(cells: [
+                  DataCell(Text(e.key)),
+                  DataCell(Text('${percent.toStringAsFixed(1)}%')),
+                  DataCell(Text('${e.value.toStringAsFixed(1)}kg')),
+                ]);
+              }).toList(),
+            ),
           ),
         ),
       ],


### PR DESCRIPTION
## Summary
- Replace report tab with new distribution view
- Add category dropdown and 30/60/1-year range toggle
- Display pie chart and detailed volume list based on selection

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b65a6e39c48321ae7bb1bb03f0baf3