### PR TITLE
Preserve workout settings without history

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -166,12 +166,6 @@ class _HomePageState extends State<HomePage> {
     });
     if (_selectedExercise != null) {
       await _loadLastWorkout(_selectedExercise!);
-    } else {
-      setState(() {
-        reps = 10;
-        weight = 10;
-        _timerSeconds = 60;
-      });
     }
     unawaited(_saveSettings());
   }
@@ -223,19 +217,14 @@ class _HomePageState extends State<HomePage> {
 
   Future<void> _loadLastWorkout(int exerciseId) async {
     final data = await _db.getLastWorkout(exerciseId);
-    setState(() {
-      if (data != null) {
+    if (data != null) {
+      setState(() {
         reps = data['reps'] as int;
         weight = (data['weight'] as num).toDouble();
         _weightUnit = data['unit'] as String;
         _timerSeconds = data['rest_seconds'] as int;
-      } else {
-        reps = 10;
-        weight = 10;
-        _weightUnit = 'kg';
-        _timerSeconds = 60;
-      }
-    });
+      });
+    }
     unawaited(_saveSettings());
   }
 
@@ -339,11 +328,6 @@ class _HomePageState extends State<HomePage> {
                     if (id != null) {
                       unawaited(_loadLastWorkout(id));
                     } else {
-                      setState(() {
-                        reps = 10;
-                        weight = 10;
-                        _timerSeconds = 60;
-                      });
                       unawaited(_saveSettings());
                     }
                   },


### PR DESCRIPTION
## Summary
- Keep current reps, weight, and timer when selecting a category or exercise without prior workouts
- Only update fields when historical workout data exists for the selected exercise

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b8d5bfc88321af599a18900b08ff