### PR TITLE
Seed database with default data in dev mode

### DIFF
--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -132,8 +132,16 @@ class DatabaseHelper {
     await db.delete('exercises', where: 'id = ?', whereArgs: [id]);
   }
 
-  Future<void> logWorkout(
-      int exerciseId, int reps, double weight, String unit, int restSeconds) async {
+  Future<void> clearAll() async {
+    final db = await database;
+    await db.delete('workouts');
+    await db.delete('exercises');
+    await db.delete('categories');
+  }
+
+  Future<void> logWorkout(int exerciseId, int reps, double weight, String unit,
+      int restSeconds,
+      {DateTime? timestamp}) async {
     final db = await database;
     await db.insert('workouts', {
       'exercise_id': exerciseId,
@@ -141,7 +149,8 @@ class DatabaseHelper {
       'weight': weight,
       'unit': unit,
       'rest_seconds': restSeconds,
-      'timestamp': DateTime.now().millisecondsSinceEpoch,
+      'timestamp':
+          (timestamp ?? DateTime.now()).millisecondsSinceEpoch,
     });
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,53 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'database_helper.dart';
 import 'home_page.dart';
 import 'screen_util.dart';
-
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  const bool isDev = bool.fromEnvironment('IS_DEV');
+  if (isDev) {
+    await _importDevData();
+  }
   runApp(const MyApp());
+}
+
+Future<void> _importDevData() async {
+  final db = DatabaseHelper.instance;
+  await db.clearAll();
+
+  final defaultJson =
+      await rootBundle.loadString('assets/default_exercises.json');
+  final defaultData = jsonDecode(defaultJson) as Map<String, dynamic>;
+
+  final Map<String, int> exerciseIds = {};
+  for (final category in defaultData['categories'] as List<dynamic>) {
+    final categoryId = await db.insertCategory(category['name'] as String);
+    for (final exercise in category['exercises'] as List<dynamic>) {
+      final name = exercise as String;
+      final exerciseId = await db.insertExercise(categoryId, name);
+      exerciseIds[name] = exerciseId;
+    }
+  }
+
+  final recordsJson = await rootBundle.loadString('assets/test_records.json');
+  final recordsData = jsonDecode(recordsJson) as Map<String, dynamic>;
+  for (final record in recordsData['records'] as List<dynamic>) {
+    final date = DateTime.parse(record['date'] as String);
+    for (final workout in record['workouts'] as List<dynamic>) {
+      final exerciseId = exerciseIds[workout['exercise'] as String];
+      if (exerciseId == null) continue;
+      await db.logWorkout(
+        exerciseId,
+        workout['reps'] as int,
+        (workout['weight'] as num).toDouble(),
+        workout['unit'] as String,
+        workout['rest_seconds'] as int,
+        timestamp: date,
+      );
+    }
+  }
 }
 
 class MyApp extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ flutter:
   assets:
     - assets/readytowork.mp3
     - assets/default_exercises.json
+    - assets/test_records.json
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
## Summary
- Seed database with default exercises and test records when `IS_DEV` is true
- Allow seeding by clearing tables and inserting workouts with custom timestamps
- Include test record asset

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f6cfabbc83218a528448da4f24fb