### PR TITLE
feat: show today set count after rest

### DIFF
--- a/lib/database_helper.dart
+++ b/lib/database_helper.dart
@@ -175,6 +175,22 @@ class DatabaseHelper {
     });
   }
 
+  Future<int> getTodayWorkoutCount(int exerciseId) async {
+    final db = await database;
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day);
+    final end = start.add(const Duration(days: 1));
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) FROM workouts WHERE exercise_id = ? AND timestamp BETWEEN ? AND ?',
+      [
+        exerciseId,
+        start.millisecondsSinceEpoch,
+        end.millisecondsSinceEpoch,
+      ],
+    );
+    return Sqflite.firstIntValue(result) ?? 0;
+  }
+
   Future<Map<String, dynamic>?> getLastWorkout(int exerciseId) async {
     final db = await database;
     final result = await db.query('workouts',


### PR DESCRIPTION
## Summary
- show notification with exercise name and today's set count when rest ends
- long-press start button to record a set without starting timer

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bb02fe69c483219572292be1e8416b