### PR TITLE
feat: 改以真實時間差與預排通知計時

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_native_timezone/flutter_native_timezone.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 import 'database_helper.dart';
@@ -47,6 +48,8 @@ class _HomePageState extends State<HomePage> {
     super.initState();
     tz.initializeTimeZones();
     Future(() async {
+      final String tzName = await FlutterNativeTimezone.getLocalTimezone();
+      tz.setLocalLocation(tz.getLocation(tzName));
       const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
       const darwinInit = DarwinInitializationSettings();
       await _localNotifications.initialize(

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -241,7 +241,8 @@ class _HomePageState extends State<HomePage> {
       '$exerciseName今天做了$count組',
       tz.TZDateTime.from(when, tz.local),
       details,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      // 使用非精準投遞以避免要求精準鬧鐘權限
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
     );

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 import 'database_helper.dart';
@@ -48,7 +48,7 @@ class _HomePageState extends State<HomePage> {
     super.initState();
     tz.initializeTimeZones();
     Future(() async {
-      final String tzName = await FlutterNativeTimezone.getLocalTimezone();
+      final String tzName = await FlutterTimezone.getLocalTimezone();
       tz.setLocalLocation(tz.getLocation(tzName));
       const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
       const darwinInit = DarwinInitializationSettings();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -186,26 +186,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      sha256: "a9966c850de5e445331b854fa42df96a8020066d67f125a5964cbc6556643f68"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.4"
+    version: "19.4.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      sha256: "e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "6.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "9.1.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: "ed46d7ae4ec9d19e4c8fa2badac5fe27ba87a3fe387343ce726f927af074ec98"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -558,13 +566,13 @@ packages:
     source: hosted
     version: "0.7.4"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
-      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      sha256: "ffc9d5f4d1193534ef051f9254063fa53d588609418c84299956c3db9383587d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.10.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -227,6 +227,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "13b2109ad75651faced4831bf262e32559e44aa549426eab8a597610d385d934"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   fl_chart: ^0.69.0
   flutter_local_notifications: ^17.1.2
   timezone: ^0.9.2
-  flutter_native_timezone: ^2.0.0
+  flutter_timezone: ^4.1.1
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   fl_chart: ^0.69.0
   flutter_local_notifications: ^17.1.2
   timezone: ^0.9.2
+  flutter_native_timezone: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   shared_preferences: ^2.3.2
   fl_chart: ^0.69.0
   flutter_local_notifications: ^17.1.2
+  timezone: ^0.9.2
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,8 +39,8 @@ dependencies:
   flutter_slidable: ^3.0.1
   shared_preferences: ^2.3.2
   fl_chart: ^0.69.0
-  flutter_local_notifications: ^17.1.2
-  timezone: ^0.9.2
+  flutter_local_notifications: ^19.4.1
+  timezone: ^0.10.0
   flutter_timezone: ^4.1.1
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- 記錄計時結束時間並預排本地通知
- 使用 real-time 差值更新計時器，避免背景不準
- 加入 timezone 相依以支援排程

## Testing
- `flutter pub get` *(command not found: flutter)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68be4736abac83218028b4f291c17ddb