### PR TITLE
feat: keep timer accurate in background

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <application
         android:label="irondiary"
         android:name="${applicationName}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <application
         android:label="irondiary"
@@ -33,6 +34,9 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <service
+            android:name="id.flutter.flutter_background_service.BackgroundService"
+            android:foregroundServiceType="dataSync" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,7 @@ Future<void> main() async {
       initialNotificationTitle: 'IronDiary 計時器',
       initialNotificationContent: '計時中... ',
       foregroundServiceNotificationId: 888,
+      foregroundServiceTypes: [AndroidForegroundType.dataSync],
     ),
     iosConfiguration: IosConfiguration(),
   );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,68 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:flutter_background_service_android/flutter_background_service_android.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'database_helper.dart';
 import 'home_page.dart';
 import 'screen_util.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  final service = FlutterBackgroundService();
+  await service.configure(
+    androidConfiguration: AndroidConfiguration(
+      onStart: _onStart,
+      isForegroundMode: true,
+      autoStart: false,
+      notificationChannelId: 'timer_channel',
+      initialNotificationTitle: 'IronDiary 計時器',
+      initialNotificationContent: '計時中... ',
+      foregroundServiceNotificationId: 888,
+    ),
+    iosConfiguration: IosConfiguration(),
+  );
+
   const bool isDev = bool.fromEnvironment('IS_DEV');
   if (isDev) {
     await _importDevData();
   }
   runApp(const MyApp());
+}
+
+@pragma('vm:entry-point')
+void _onStart(ServiceInstance service) async {
+  DartPluginRegistrant.ensureInitialized();
+  final notifications = FlutterLocalNotificationsPlugin();
+  const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+  await notifications
+      .initialize(const InitializationSettings(android: androidInit));
+  Timer? timer;
+
+  service.on('startTimer').listen((event) {
+    timer?.cancel();
+    final seconds = event?['seconds'] as int? ?? 0;
+    final exercise = event?['exercise'] as String? ?? '';
+    final count = event?['count'] as int? ?? 0;
+    timer = Timer(Duration(seconds: seconds), () async {
+      await notifications.show(
+        0,
+        'Timer Completion',
+        '休息結束，$exercise今天做了$count組',
+        const NotificationDetails(
+          android: AndroidNotificationDetails('timer_channel', 'Rest Timer'),
+        ),
+      );
+      service.stopSelf();
+    });
+  });
+
+  service.on('stopTimer').listen((event) {
+    timer?.cancel();
+    service.stopSelf();
+  });
 }
 
 Future<void> _importDevData() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_background_service/flutter_background_service.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,9 @@ dependencies:
   shared_preferences: ^2.3.2
   fl_chart: ^0.69.0
   flutter_local_notifications: ^17.1.2
+  flutter_background_service: ^5.1.0
+  flutter_background_service_android: ^6.3.1
+  flutter_background_service_ios: ^5.0.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,8 +40,8 @@ dependencies:
   shared_preferences: ^2.3.2
   fl_chart: ^0.69.0
   flutter_local_notifications: ^17.1.2
-  flutter_background_service: ^5.1.0
-  flutter_background_service_android: ^6.3.1
+  flutter_background_service: ^5.1.1
+  flutter_background_service_android: ^6.4.0
   flutter_background_service_ios: ^5.0.3
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add flutter_background_service to keep rest timer running when screen locks
- trigger completion notification from background service
- declare foreground service permissions

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format lib/main.dart lib/home_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8cd8541c8321841be8f8a859b79d