### PR TITLE
Persist category/exercise order and adjust timer lock

### DIFF
--- a/lib/exercise_settings_page.dart
+++ b/lib/exercise_settings_page.dart
@@ -33,7 +33,9 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
           // Convert the query result to a modifiable list. Sqflite's
           // QueryResultSet is read-only and attempting to modify it
           // (e.g. during reordering) will throw an UnsupportedError.
-          'exercises': List<Map<String, dynamic>>.from(exsList[i]),
+          'exercises': [
+            for (final ex in exsList[i]) Map<String, dynamic>.from(ex)
+          ],
         }
     ];
     setState(() {

--- a/lib/exercise_settings_page.dart
+++ b/lib/exercise_settings_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'database_helper.dart';
@@ -44,18 +46,28 @@ class _ExerciseSettingsPageState extends State<ExerciseSettingsPage> {
       if (newIndex > oldIndex) newIndex -= 1;
       final item = _categories.removeAt(oldIndex);
       _categories.insert(newIndex, item);
+      for (var i = 0; i < _categories.length; i++) {
+        _categories[i]['sort_order'] = i;
+      }
     });
+    final orderedIds = _categories.map((c) => c['id'] as int).toList();
+    unawaited(_db.updateCategoryOrders(orderedIds));
   }
 
   void _reorderExercises(int catId, int oldIndex, int newIndex) {
+    final exercises = _categories
+        .firstWhere((c) => c['id'] == catId)['exercises']
+        as List<Map<String, dynamic>>;
     setState(() {
-      final exercises = _categories
-          .firstWhere((c) => c['id'] == catId)['exercises']
-          as List<Map<String, dynamic>>;
       if (newIndex > oldIndex) newIndex -= 1;
       final item = exercises.removeAt(oldIndex);
       exercises.insert(newIndex, item);
+      for (var i = 0; i < exercises.length; i++) {
+        exercises[i]['sort_order'] = i;
+      }
     });
+    final orderedIds = exercises.map((e) => e['id'] as int).toList();
+    unawaited(_db.updateExerciseOrders(catId, orderedIds));
   }
 
   void _showCategoryDialog({int? id, String? name}) {


### PR DESCRIPTION
## Summary
- limit the AbsorbPointer used during timing to the timer button itself so the rest of the page stays interactive
- store and query category/exercise sort orders so dropdowns follow the order configured in settings
- assign sort orders when importing defaults and provide helpers that persist reordering actions

## Testing
- Not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c8c08430808321bbdd33dd51bffa03